### PR TITLE
ci/[NOISSUE] fix frontend build

### DIFF
--- a/.github/workflows/ci-cd-staging.yaml
+++ b/.github/workflows/ci-cd-staging.yaml
@@ -1,7 +1,9 @@
 name: Frontend CI/CD
 
 on:
-  workflow_call:  # Allows this workflow to be triggered by another workflow
+  push:
+    branches:
+      - main
   workflow_dispatch: # enables manual trigger
 
 permissions:


### PR DESCRIPTION
# Resolves NOISSUE

## Description

Changed the package building on the frontend when a PR is merged.

Removed the frontend workflow trigger to build the package and push it to ghcr.io
This change comes together with a change in the backend to trigger frontend workflows after a backend PR is merged.

## Checklist

Please make sure that the following items have been completed before submitting this pull request:

- [x] Code has been properly tested
- [x] All tests pass successfully
- [x] Code has been reviewed for clarity, readability, and maintainability
- [x] Code has been properly documented with comments
