### PR TITLE
Fix/#48 fix hydration error

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The app will now be accessible at [http://localhost:3000](http://localhost:3000)
 
 Alternatively for the relase [Docker](https://www.docker.com) is required.
 
-The frontend image can be ran with the following command:
+The frontend image can be run with the following command:
 ```bash
 docker-compose -f ./docker/compose.yaml up --build
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -7470,10 +7470,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
-      "license": "MIT",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
+      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "dependencies": {
         "esbuild": "^0.25.0",
         "postcss": "^8.5.3",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,10 +5,12 @@ import PageHeader from '@/components/PageHeader';
 import WIPSection from "@/components/WIPSection";
 
 const HomePage = () => {
+    // Store the formatted date to display on the UI
     const [formattedDate, setFormattedDate] = useState<string | null>(null);
 
     useEffect(() => {
         // TODO: Maybe make the locale selection dynamic depending on the user's navigator.language property
+        // Format the current date using a fixed Swiss German locale ('de-CH')
         const userLocale = 'de-CH';
         const date = new Intl.DateTimeFormat(userLocale, {
             weekday: 'long',
@@ -16,6 +18,7 @@ const HomePage = () => {
             month: '2-digit',
             year: 'numeric',
         }).format(new Date());
+
         setFormattedDate(date);
     }, []);
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,23 @@
 'use client';
 
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import PageHeader from '@/components/PageHeader';
 import WIPSection from "@/components/WIPSection";
 
 const HomePage = () => {
-    const formattedDate = new Intl.DateTimeFormat('de-CH', {
-        weekday: 'long',
-        day: '2-digit',
-        month: '2-digit',
-        year: 'numeric',
-    }).format(new Date());
+    const [formattedDate, setFormattedDate] = useState<string | null>(null);
+
+    useEffect(() => {
+        // TODO: Maybe make the locale selection dynamic depending on the user's navigator.language property
+        const userLocale = 'de-CH';
+        const date = new Intl.DateTimeFormat(userLocale, {
+            weekday: 'long',
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+        }).format(new Date());
+        setFormattedDate(date);
+    }, []);
 
     return (
         <>


### PR DESCRIPTION
# Resolves #48

## Description

This PR resolves a hydration issue on the home page that was caused by formatting the current date using `Intl.DateTimeFormat` during initial rendering. Since the server and client could produce different outputs based on locale settings, React threw a hydration mismatch error.

The solution is to move the formatting of the current date into a `useEffect` hook to ensure it only runs on the client. The formatted string is then stored in a state to safely display it after mount.

**Note:** The locale is currently hardcoded to `de-CH`. In order to display the date correctly and sensibly in the various countries, it's better to use `navigator.language` property to use the client's locale for the formatting. 

Additionally, I updated the `vite` dependency because of a moderate vulnerability and fixed a small grammar mistake in the README file.

## Checklist

Please make sure that the following items have been completed before submitting this pull request:

- [x] Code has been properly tested
- [x] All tests pass successfully
- [x] Code has been reviewed for clarity, readability, and maintainability
- [x] Code has been properly documented with comments
