### PR TITLE
Refactoring of Calendar

### DIFF
--- a/src/app/api/calendar/lecturers/[lecturer]/route.ts
+++ b/src/app/api/calendar/lecturers/[lecturer]/route.ts
@@ -1,0 +1,1 @@
+// call lectuerer

--- a/src/app/api/calendar/lecturers/[lecturer]/route.ts
+++ b/src/app/api/calendar/lecturers/[lecturer]/route.ts
@@ -1,1 +1,1 @@
-// call lectuerer
+// TODO: get schedule of lecturer

--- a/src/app/api/calendar/lecturers/[lecturer]/route.ts
+++ b/src/app/api/calendar/lecturers/[lecturer]/route.ts
@@ -1,1 +1,47 @@
-// TODO: get schedule of lecturer
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Forwards a GET request to the external ZHAW Engineering API to fetch the schedule
+ * for a specific student shortName and date.
+ * The student is taken from the dynamic route segment `[student]`.
+ */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ lecturer: string }> }) {
+  try {
+    console.log(req);
+    const { lecturer: student }= await params;
+
+    // Extract params
+    const rawDateStr = req.nextUrl.searchParams.get('startingAt') ?? new Date().toISOString().split('T')[0];
+    const date = new Date(rawDateStr);
+    const startingAt = date.toISOString().split('T')[0];
+
+    console.log("starting at:" + startingAt);
+
+    const scheduleRes = await fetch(
+      `https://api.apps.engineering.zhaw.ch/v1/schedules/lecturer/${student}?startingAt=${startingAt}`,
+      {
+        headers: {
+          'User-Agent': 'StudyConnect (https://github.com/StudyConnect-ZHAW)',
+          Accept: 'application/json',
+        },
+      }
+    );
+
+    if (scheduleRes.status === 404) {
+      return NextResponse.json({ days: [] });
+    }
+
+    if (!scheduleRes.ok) {
+      return NextResponse.json({ error: 'Failed to fetch ZHAW calendar' }, { status: scheduleRes.status });
+    }
+
+    const schedule = await scheduleRes.json();
+
+    return NextResponse.json(schedule);
+
+  } catch (error) {
+    console.error('API-Error:', error);
+
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/calendar/lecturers/[lecturer]/route.ts
+++ b/src/app/api/calendar/lecturers/[lecturer]/route.ts
@@ -7,7 +7,6 @@ import { NextRequest, NextResponse } from 'next/server';
  */
 export async function GET(req: NextRequest, { params }: { params: Promise<{ lecturer: string }> }) {
   try {
-    console.log(req);
     const { lecturer }= await params;
 
     // Extract params

--- a/src/app/api/calendar/lecturers/[lecturer]/route.ts
+++ b/src/app/api/calendar/lecturers/[lecturer]/route.ts
@@ -6,41 +6,31 @@ import { NextRequest, NextResponse } from 'next/server';
  * The lecturer is taken from the dynamic route segment `[lecturer]`.
  */
 export async function GET(req: NextRequest, { params }: { params: Promise<{ lecturer: string }> }) {
-  try {
-    const { lecturer }= await params;
+  const { lecturer } = await params;
 
-    // Extract params
-    const rawDateStr = req.nextUrl.searchParams.get('startingAt') ?? new Date().toISOString().split('T')[0];
-    const date = new Date(rawDateStr);
-    const startingAt = date.toISOString().split('T')[0];
+  const rawDateStr = req.nextUrl.searchParams.get('startingAt') ?? new Date().toISOString().split('T')[0];
+  const date = new Date(rawDateStr);
+  const startingAt = date.toISOString().split('T')[0];
 
-    console.log("starting at:" + startingAt);
-
-    const scheduleRes = await fetch(
-      `https://api.apps.engineering.zhaw.ch/v1/schedules/lecturers/${lecturer}?startingAt=${startingAt}`,
-      {
-        headers: {
-          'User-Agent': 'StudyConnect (https://github.com/StudyConnect-ZHAW)',
-          Accept: 'application/json',
-        },
-      }
-    );
-
-    if (scheduleRes.status === 404) {
-      return NextResponse.json({ days: [] });
+  const scheduleRes = await fetch(
+    `https://api.apps.engineering.zhaw.ch/v1/schedules/lecturers/${lecturer}?startingAt=${startingAt}`,
+    {
+      headers: {
+        'User-Agent': 'StudyConnect (https://github.com/StudyConnect-ZHAW)',
+        Accept: 'application/json',
+      },
     }
+  );
 
-    if (!scheduleRes.ok) {
-      return NextResponse.json({ error: 'Failed to fetch ZHAW calendar' }, { status: scheduleRes.status });
-    }
-
-    const schedule = await scheduleRes.json();
-
-    return NextResponse.json(schedule);
-
-  } catch (error) {
-    console.error('API-Error:', error);
-
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  if (scheduleRes.status === 404) {
+    return NextResponse.json({ days: [] });
   }
+
+  if (!scheduleRes.ok) {
+    return NextResponse.json({ error: 'Failed to fetch ZHAW calendar' }, { status: scheduleRes.status });
+  }
+
+  const schedule = await scheduleRes.json();
+
+  return NextResponse.json(schedule);
 }

--- a/src/app/api/calendar/lecturers/[lecturer]/route.ts
+++ b/src/app/api/calendar/lecturers/[lecturer]/route.ts
@@ -2,13 +2,13 @@ import { NextRequest, NextResponse } from 'next/server';
 
 /**
  * Forwards a GET request to the external ZHAW Engineering API to fetch the schedule
- * for a specific student shortName and date.
- * The student is taken from the dynamic route segment `[student]`.
+ * for a specific lecturer shortName and date.
+ * The lecturer is taken from the dynamic route segment `[lecturer]`.
  */
 export async function GET(req: NextRequest, { params }: { params: Promise<{ lecturer: string }> }) {
   try {
     console.log(req);
-    const { lecturer: student }= await params;
+    const { lecturer }= await params;
 
     // Extract params
     const rawDateStr = req.nextUrl.searchParams.get('startingAt') ?? new Date().toISOString().split('T')[0];
@@ -18,7 +18,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ lect
     console.log("starting at:" + startingAt);
 
     const scheduleRes = await fetch(
-      `https://api.apps.engineering.zhaw.ch/v1/schedules/lecturer/${student}?startingAt=${startingAt}`,
+      `https://api.apps.engineering.zhaw.ch/v1/schedules/lecturers/${lecturer}?startingAt=${startingAt}`,
       {
         headers: {
           'User-Agent': 'StudyConnect (https://github.com/StudyConnect-ZHAW)',

--- a/src/app/api/calendar/lecturers/route.ts
+++ b/src/app/api/calendar/lecturers/route.ts
@@ -5,30 +5,21 @@ import { NextResponse } from 'next/server';
  * This route acts as a proxy, adding necessary headers and passing the data back to the frontend.
  */
 export async function GET() {
-
-  try {
-
-    const lecturersRes = await fetch(
-      `https://api.apps.engineering.zhaw.ch/v1/schedules/lecturers/`,
-      {
-        headers: {
-          'User-Agent': 'StudyConnect (https://github.com/StudyConnect-ZHAW)',
-          Accept: 'application/json',
-        },
-      }
-    );
-
-    if (!lecturersRes.ok) {
-      return NextResponse.json({ error: 'Failed to fetch ZHAW calendar' }, { status: lecturersRes.status });
+  const lecturersRes = await fetch(
+    `https://api.apps.engineering.zhaw.ch/v1/schedules/lecturers/`,
+    {
+      headers: {
+        'User-Agent': 'StudyConnect (https://github.com/StudyConnect-ZHAW)',
+        Accept: 'application/json',
+      },
     }
-    
-    const lecturers = await lecturersRes.json();
+  );
 
-    return NextResponse.json(lecturers);
-
-  } catch (error) {
-    console.error('API-Error:', error);
-
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  if (!lecturersRes.ok) {
+    return NextResponse.json({ error: 'Failed to fetch ZHAW calendar' }, { status: lecturersRes.status });
   }
+
+  const lecturers = await lecturersRes.json();
+
+  return NextResponse.json(lecturers);
 }

--- a/src/app/api/calendar/lecturers/route.ts
+++ b/src/app/api/calendar/lecturers/route.ts
@@ -21,9 +21,8 @@ export async function GET() {
     if (!lecturersRes.ok) {
       return NextResponse.json({ error: 'Failed to fetch ZHAW calendar' }, { status: lecturersRes.status });
     }
-
+    
     const lecturers = await lecturersRes.json();
-    console.log("Lecturers: " + lecturers);
 
     return NextResponse.json(lecturers);
 

--- a/src/app/api/calendar/lecturers/route.ts
+++ b/src/app/api/calendar/lecturers/route.ts
@@ -1,1 +1,35 @@
-// get all lectueres
+import { NextResponse } from 'next/server';
+
+/**
+ * Forwards a GET request to the external ZHAW Engineering API to fetch all lecturer shortNames.
+ * This route acts as a proxy, adding necessary headers and passing the data back to the frontend.
+ */
+export async function GET() {
+
+  try {
+
+    const lecturersRes = await fetch(
+      `https://api.apps.engineering.zhaw.ch/v1/schedules/students/`,
+      {
+        headers: {
+          'User-Agent': 'StudyConnect (https://github.com/StudyConnect-ZHAW)',
+          Accept: 'application/json',
+        },
+      }
+    );
+
+    if (!lecturersRes.ok) {
+      return NextResponse.json({ error: 'Failed to fetch ZHAW calendar' }, { status: lecturersRes.status });
+    }
+
+    const lecturers = await lecturersRes.json();
+    console.log("Lecturers: " + lecturers);
+
+    return NextResponse.json(lecturers);
+
+  } catch (error) {
+    console.error('API-Error:', error);
+
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/calendar/lecturers/route.ts
+++ b/src/app/api/calendar/lecturers/route.ts
@@ -1,0 +1,1 @@
+// get all lectueres

--- a/src/app/api/calendar/lecturers/route.ts
+++ b/src/app/api/calendar/lecturers/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
   try {
 
     const lecturersRes = await fetch(
-      `https://api.apps.engineering.zhaw.ch/v1/schedules/students/`,
+      `https://api.apps.engineering.zhaw.ch/v1/schedules/lecturers/`,
       {
         headers: {
           'User-Agent': 'StudyConnect (https://github.com/StudyConnect-ZHAW)',

--- a/src/app/api/calendar/students/[student]/route.ts
+++ b/src/app/api/calendar/students/[student]/route.ts
@@ -6,25 +6,16 @@ import { NextRequest, NextResponse } from 'next/server';
  * The student is taken from the dynamic route segment `[student]`.
  */
 export async function GET(req: NextRequest, { params }: { params: Promise<{ student: string }> }) {
-  
-  // TODO: request to get all students and all lectureres cache it in a list, 
-  // look if shortname part of student, or part of lecturer list, if neither dont call api !
-
   try {
     console.log(req);
     const { student }= await params;
 
     // Extract params
     const rawDateStr = req.nextUrl.searchParams.get('startingAt') ?? new Date().toISOString().split('T')[0];
-    const view = req.nextUrl.searchParams.get('view') ?? '';
     const date = new Date(rawDateStr);
-
-    // ZHAW weeks start on Monday but API returns Sunday, shift only for non-day views
-    if (view !== 'timeGridDay') {
-      date.setDate(date.getDate() + 1);
-    }
-
     const startingAt = date.toISOString().split('T')[0];
+
+    console.log("starting at:" + startingAt);
 
     const scheduleRes = await fetch(
       `https://api.apps.engineering.zhaw.ch/v1/schedules/students/${student}?startingAt=${startingAt}`,

--- a/src/app/api/calendar/students/[student]/route.ts
+++ b/src/app/api/calendar/students/[student]/route.ts
@@ -7,7 +7,6 @@ import { NextRequest, NextResponse } from 'next/server';
  */
 export async function GET(req: NextRequest, { params }: { params: Promise<{ student: string }> }) {
   try {
-    console.log(req);
     const { student }= await params;
 
     // Extract params

--- a/src/app/api/calendar/students/[student]/route.ts
+++ b/src/app/api/calendar/students/[student]/route.ts
@@ -6,41 +6,31 @@ import { NextRequest, NextResponse } from 'next/server';
  * The student is taken from the dynamic route segment `[student]`.
  */
 export async function GET(req: NextRequest, { params }: { params: Promise<{ student: string }> }) {
-  try {
-    const { student }= await params;
+  const { student } = await params;
 
-    // Extract params
-    const rawDateStr = req.nextUrl.searchParams.get('startingAt') ?? new Date().toISOString().split('T')[0];
-    const date = new Date(rawDateStr);
-    const startingAt = date.toISOString().split('T')[0];
+  const rawDateStr = req.nextUrl.searchParams.get('startingAt') ?? new Date().toISOString().split('T')[0];
+  const date = new Date(rawDateStr);
+  const startingAt = date.toISOString().split('T')[0];
 
-    console.log("starting at:" + startingAt);
-
-    const scheduleRes = await fetch(
-      `https://api.apps.engineering.zhaw.ch/v1/schedules/students/${student}?startingAt=${startingAt}`,
-      {
-        headers: {
-          'User-Agent': 'StudyConnect (https://github.com/StudyConnect-ZHAW)',
-          Accept: 'application/json',
-        },
-      }
-    );
-
-    if (scheduleRes.status === 404) {
-      return NextResponse.json({ days: [] });
+  const scheduleRes = await fetch(
+    `https://api.apps.engineering.zhaw.ch/v1/schedules/students/${student}?startingAt=${startingAt}`,
+    {
+      headers: {
+        'User-Agent': 'StudyConnect (https://github.com/StudyConnect-ZHAW)',
+        Accept: 'application/json',
+      },
     }
+  );
 
-    if (!scheduleRes.ok) {
-      return NextResponse.json({ error: 'Failed to fetch ZHAW calendar' }, { status: scheduleRes.status });
-    }
-
-    const schedule = await scheduleRes.json();
-
-    return NextResponse.json(schedule);
-
-  } catch (error) {
-    console.error('API-Error:', error);
-
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  if (scheduleRes.status === 404) {
+    return NextResponse.json({ days: [] });
   }
+
+  if (!scheduleRes.ok) {
+    return NextResponse.json({ error: 'Failed to fetch ZHAW calendar' }, { status: scheduleRes.status });
+  }
+
+  const schedule = await scheduleRes.json();
+
+  return NextResponse.json(schedule);
 }

--- a/src/app/api/calendar/students/[student]/route.ts
+++ b/src/app/api/calendar/students/[student]/route.ts
@@ -1,18 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-/*
- * API Route: /api/calendar
- * Fetches the ZHAW schedule for authenticated users with a valid ZHAW email.
- * Requires a valid JWT in the 'access_token' cookie.
+/**
+ * Forwards a GET request to the external ZHAW Engineering API to fetch the schedule
+ * for a specific student shortName and date.
+ * The student is taken from the dynamic route segment `[student]`.
  */
 export async function GET(req: NextRequest, { params }: { params: Promise<{ student: string }> }) {
   
   // TODO: request to get all students and all lectureres cache it in a list, 
   // look if shortname part of student, or part of lecturer list, if neither dont call api !
 
-  // TODO: separate api calls and logic dont do everything in one file 
-  // (hooks, lib/api, handlers, calendar.ts with mapZhawDaysToEvents)
-  
   try {
     console.log(req);
     const { student }= await params;
@@ -52,7 +49,6 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ stud
     return NextResponse.json(schedule);
 
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error('API-Error:', error);
 
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/src/app/api/calendar/students/route.ts
+++ b/src/app/api/calendar/students/route.ts
@@ -5,30 +5,21 @@ import { NextResponse } from 'next/server';
  * This route acts as a proxy, adding necessary headers and passing the data back to the frontend.
  */
 export async function GET() {
-
-  try {
-
-    const studentsRes = await fetch(
-      `https://api.apps.engineering.zhaw.ch/v1/schedules/students/`,
-      {
-        headers: {
-          'User-Agent': 'StudyConnect (https://github.com/StudyConnect-ZHAW)',
-          Accept: 'application/json',
-        },
-      }
-    );
-
-    if (!studentsRes.ok) {
-      return NextResponse.json({ error: 'Failed to fetch ZHAW calendar' }, { status: studentsRes.status });
+  const studentsRes = await fetch(
+    `https://api.apps.engineering.zhaw.ch/v1/schedules/students/`,
+    {
+      headers: {
+        'User-Agent': 'StudyConnect (https://github.com/StudyConnect-ZHAW)',
+        Accept: 'application/json',
+      },
     }
+  );
 
-    const students = await studentsRes.json();
-
-    return NextResponse.json(students);
-
-  } catch (error) {
-    console.error('API-Error:', error);
-
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  if (!studentsRes.ok) {
+    return NextResponse.json({ error: 'Failed to fetch ZHAW calendar' }, { status: studentsRes.status });
   }
+
+  const students = await studentsRes.json();
+
+  return NextResponse.json(students);
 }

--- a/src/app/api/calendar/students/route.ts
+++ b/src/app/api/calendar/students/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Forwards a GET request to the external ZHAW Engineering API to fetch all student shortNames.
+ * This route acts as a proxy, adding necessary headers and passing the data back to the frontend.
+ */
+export async function GET() {
+
+  try {
+
+    const studentsRes = await fetch(
+      `https://api.apps.engineering.zhaw.ch/v1/schedules/students/`,
+      {
+        headers: {
+          'User-Agent': 'StudyConnect (https://github.com/StudyConnect-ZHAW)',
+          Accept: 'application/json',
+        },
+      }
+    );
+
+    if (!studentsRes.ok) {
+      return NextResponse.json({ error: 'Failed to fetch ZHAW calendar' }, { status: studentsRes.status });
+    }
+
+    const students = await studentsRes.json();
+
+    return NextResponse.json(students);
+
+  } catch (error) {
+    console.error('API-Error:', error);
+
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,18 +1,15 @@
 'use client';
 
-import React, { useCallback, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import enLocale from '@fullcalendar/core/locales/en-gb';
 import deLocale from '@fullcalendar/core/locales/de';
 import { useTranslation } from 'react-i18next';
-import { type EventInput, type EventSourceFuncArg, formatDate } from '@fullcalendar/core';
+import { formatDate } from '@fullcalendar/core';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
-
-import { mapZhawDaysToEvents } from '@/lib/calendar';
-import { fetchPublicHolidays } from '@/lib/api/openholidays';
-import type { ZhawSchedule } from '@/types/calendar';
+import { useCalendar } from '@/hooks/useCalendar';
 
 interface CalendarProps {
     initialView?: 'dayGridMonth' | 'timeGridWeek' | 'timeGridDay' | 'listWeek';
@@ -33,111 +30,31 @@ export default function Calendar({ initialView = 'dayGridMonth', showHeader = tr
   const { user, loading: loadingUser } = useCurrentUser();
 
   const email = user?.email?.toLowerCase() ?? '';
-  const shortName = email.includes('@') ? email.split('@')[0] : null;
+  const shortName = email.includes('@') ? email.split('@')[0] : '';
 
-  //   const [events, setEvents] ≠ useState([]);
+  const {
+    students,
+    loading: loadingCalendar,
+    loadStudents,
+    fetchEventsDynamically,
+  } = useCalendar(shortName);
 
-  const fetchEventsDynamically = useCallback(
-    async (
-      fetchInfo: EventSourceFuncArg,
-      successCallback: (events: EventInput[]) => void,
-      failureCallback: (error: Error) => void
-    ) => {
-      try {
-        const viewStart = new Date(fetchInfo.start ?? new Date());
-        const viewEnd = new Date(fetchInfo.end ?? new Date());
+  useEffect(() => {
+    loadStudents();
+  }, [loadStudents]);
 
-        const viewType = (fetchInfo as { view?: { type?: string } }).view?.type ?? initialView;
-        const isDailyView = viewType === 'timeGridDay';
-
-        const allEvents: EventInput[] = [];
-        const fetchedWeeks = new Set<string>();
-        const maxDays = 7;
-
-        // Add Swiss public holidays for the current year
-        const publicHolidays = await fetchPublicHolidays(viewStart.getFullYear());
-        allEvents.push(...publicHolidays);
-
-        if (isDailyView) {
-          const adjustedDate = new Date(viewStart);
-          const startingAt = adjustedDate.toISOString().split('T')[0];
-
-          // Fetch calendar for a single day
-          const res = await fetch(`/api/calendar/students/${shortName}?startingAt=${startingAt}&view=${viewType}`);
-
-          if (!res.ok) {return;}
-
-          const data: ZhawSchedule = await res.json();
-
-          const filtered = data.days.map((day) => ({
-            ...day,
-            events: (day.events ?? []).filter((e) => e.type !== 'Holiday'),
-          }));
-
-          // Convert to FullCalendar format and add to event list
-          allEvents.push(...mapZhawDaysToEvents({ days: filtered }));
-        } else {
-          // Weekly/monthly view – loop through each week
-          for (let date = new Date(viewStart); date <= viewEnd; date.setDate(date.getDate() + maxDays)) {
-            const adjustedDate = new Date(date);
-
-            // Shift by +1 day because ZHAW calendar weeks start on Monday (API returns Sunday)
-            adjustedDate.setDate(adjustedDate.getDate() + 1);
-
-            const startingAt = adjustedDate.toISOString().split('T')[0];
-
-            // Avoid duplicate API requests for the same week
-            if (fetchedWeeks.has(startingAt)) {
-              continue;
-            }
-            fetchedWeeks.add(startingAt);
-
-            // Fetch calendar for the current week
-            const res = await fetch(`/api/calendar/students/${shortName}?startingAt=${startingAt}&view=${viewType}`);
-            if (!res.ok) {continue;}
-
-            const data: ZhawSchedule = await res.json();
-
-            // Check if the week is empty (no regular events, only holidays or none)
-            const isWeekEmpty =
-              !data.days || data.days.length === 0 ||
-              data.days.every((day) => !day.events || day.events.every((e) => e.type === 'Holiday'));
-
-            if (isWeekEmpty) {
-              // Add placeholder event to indicate semester break
-              const end = new Date(adjustedDate);
-              end.setDate(end.getDate() + 7);
-              allEvents.push({
-                title: t('semesterBreak'),
-                start: startingAt,
-                end: end.toISOString().split('T')[0],
-                allDay: true,
-                color: '#F85A6D',
-              });
-            } else {
-              // Filter out holidays and map events to calendar format
-              const filtered = data.days.map((day) => ({
-                ...day,
-                events: (day.events ?? []).filter((e) => e.type !== 'Holiday'),
-              }));
-              allEvents.push(...mapZhawDaysToEvents({ days: filtered }));
-            }
-          }
-        }
-        console.log(allEvents);
-
-        successCallback(allEvents);
-      } catch (err) {
-        failureCallback(err as Error);
-      }
-    },
-    [initialView, shortName, t]
-  );
-
-  if (!user || !user.email || loadingUser) {
+  if (loadingUser || loadingCalendar) {
     return (
       <div className="flex items-center justify-center h-full text-primary text-xl">
         {t('common:loading')}
+      </div>
+    );
+  }
+
+  if (!shortName || !students.includes(shortName)) {
+    return (
+      <div className="flex items-center justify-center h-full text-primary text-xl">
+        {t('calendar:noStudentAccess')}
       </div>
     );
   }

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -14,7 +14,7 @@ import { useCalendar } from '@/hooks/useCalendar';
 interface CalendarProps {
     initialView?: 'dayGridMonth' | 'timeGridWeek' | 'timeGridDay';
     showHeader?: boolean;
-  }
+}
 
 /*
 * Calendar component for displaying ZHAW schedule and Swiss public holidays
@@ -34,15 +34,13 @@ export default function Calendar({ initialView = 'dayGridMonth', showHeader = tr
 
   const {
     loading: loadingCalendar,
-    loadStudents,
-    loadLecturers,
+    determineUserRole,
     fetchEventsDynamically,
   } = useCalendar(shortName);
 
   useEffect(() => {
-    loadStudents();
-    loadLecturers();
-  }, [loadStudents, loadLecturers]);
+    determineUserRole();
+  }, [determineUserRole]);
 
   if (loadingUser || loadingCalendar) {
     return (

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -35,12 +35,14 @@ export default function Calendar({ initialView = 'dayGridMonth', showHeader = tr
   const {
     loading: loadingCalendar,
     loadStudents,
+    loadLecturers,
     fetchEventsDynamically,
   } = useCalendar(shortName);
 
   useEffect(() => {
     loadStudents();
-  }, [loadStudents]);
+    loadLecturers();
+  }, [loadStudents, loadLecturers]);
 
   if (loadingUser || loadingCalendar) {
     return (
@@ -89,7 +91,7 @@ export default function Calendar({ initialView = 'dayGridMonth', showHeader = tr
            * Otherwise let FullCalendar render its default styled event.
            **/
           eventContent={
-            initialView === 'timeGridDay' || initialView === 'timeGridWeek'
+            initialView === 'timeGridDay'
               ? (arg) => {
                 const room = arg.event.extendedProps.room;
 

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -12,7 +12,7 @@ import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useCalendar } from '@/hooks/useCalendar';
 
 interface CalendarProps {
-    initialView?: 'dayGridMonth' | 'timeGridWeek' | 'timeGridDay' | 'listWeek';
+    initialView?: 'dayGridMonth' | 'timeGridWeek' | 'timeGridDay';
     showHeader?: boolean;
   }
 
@@ -33,7 +33,6 @@ export default function Calendar({ initialView = 'dayGridMonth', showHeader = tr
   const shortName = email.includes('@') ? email.split('@')[0] : '';
 
   const {
-    students,
     loading: loadingCalendar,
     loadStudents,
     fetchEventsDynamically,
@@ -47,14 +46,6 @@ export default function Calendar({ initialView = 'dayGridMonth', showHeader = tr
     return (
       <div className="flex items-center justify-center h-full text-primary text-xl">
         {t('common:loading')}
-      </div>
-    );
-  }
-
-  if (!shortName || !students.includes(shortName)) {
-    return (
-      <div className="flex items-center justify-center h-full text-primary text-xl">
-        {t('calendar:noStudentAccess')}
       </div>
     );
   }

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -52,7 +52,7 @@ export default function Calendar({ initialView = 'dayGridMonth', showHeader = tr
 
   return (
     <div className="flex-grow flex items-center justify-center h-full">
-      <div className="w-full max-w-4xl h-full">
+      <div className="w-full max-w-4xl h-full border-main rounded-lg p-2">
         <FullCalendar
           plugins={[dayGridPlugin, timeGridPlugin]}
           initialView={initialView}

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -5,6 +5,11 @@ import { mapZhawDaysToEvents } from '@/lib/calendar';
 import type { EventInput, EventSourceFuncArg } from '@fullcalendar/core';
 import { useTranslation } from 'react-i18next';
 
+/**
+ * Custom hook to manage loading student/lecturer lists and fetching calendar events.
+ *
+ * @param shortName The user shortName (e.g., ZHAW login) used to fetch personalized schedules.
+ */
 export function useCalendar(shortName: string) {
   const [students, setStudents] = useState<string[]>([]);
   const [lecturers, setLecturers] = useState<string[]>([]);
@@ -12,7 +17,7 @@ export function useCalendar(shortName: string) {
   const { t } = useTranslation(['calendar']);
 
   /**
-   * Load only the list of students.
+   * Loads the list of students from the backend.
    */
   const loadStudents = useCallback(async () => {
     setLoading(true);
@@ -28,7 +33,7 @@ export function useCalendar(shortName: string) {
   }, []);
 
   /**
-   * Load the list of lecturers.
+   * Loads the list of lecturers from the backend.
    */
   const loadLecturers = useCallback(async () => {
     setLoading(true);
@@ -44,7 +49,7 @@ export function useCalendar(shortName: string) {
   }, []);
 
   /**
-   * Fetch dynamic calendar events.
+   * Fetch dynamic calendar events based on the selected view and date range.
    */
   const fetchEventsDynamically = useCallback(
     async (
@@ -57,54 +62,27 @@ export function useCalendar(shortName: string) {
         const viewEnd = new Date(fetchInfo.end ?? new Date());
         const viewType = (fetchInfo as { view?: { type?: string } }).view?.type ?? 'timeGridWeek';
         const isDailyView = viewType === 'timeGridDay';
-        const allEvents: EventInput[] = [];
-        const fetchedWeeks = new Set<string>();
-        const maxDays = 7;
 
-        // Add Swiss public holidays
+        const allEvents: EventInput[] = [];
+
+        // Always add Swiss public holidays
         const publicHolidays = await fetchPublicHolidays(viewStart.getFullYear());
         allEvents.push(...publicHolidays);
 
+        // If user is not a student → skip ZHAW API calls, only return holidays
+        if (!students.includes(shortName) && !lecturers.includes(shortName)) {
+          successCallback(allEvents);
+
+          return;
+        }
+
+        // Add ZHAW schedule events
         if (isDailyView) {
-          const startingAt = viewStart.toISOString().split('T')[0];
-          const data = await fetchZhawSchedule(shortName, startingAt, viewType);
-          const filtered = data.days.map((day) => ({
-            ...day,
-            events: (day.events ?? []).filter((e) => e.type !== 'Holiday'),
-          }));
-          allEvents.push(...mapZhawDaysToEvents({ days: filtered }));
+          const dailyEvents = await fetchDailyView(shortName, viewStart, viewType);
+          allEvents.push(...dailyEvents);
         } else {
-          for (let date = new Date(viewStart); date <= viewEnd; date.setDate(date.getDate() + maxDays)) {
-            const adjustedDate = new Date(date);
-            adjustedDate.setDate(adjustedDate.getDate() + 1);
-            const startingAt = adjustedDate.toISOString().split('T')[0];
-
-            if (fetchedWeeks.has(startingAt)) {continue;}
-            fetchedWeeks.add(startingAt);
-
-            const data = await fetchZhawSchedule(shortName, startingAt, viewType);
-            const isWeekEmpty =
-              !data.days || data.days.length === 0 ||
-              data.days.every((day) => !day.events || day.events.every((e) => e.type === 'Holiday'));
-
-            if (isWeekEmpty) {
-              const end = new Date(adjustedDate);
-              end.setDate(end.getDate() + 7);
-              allEvents.push({
-                title: t('semesterBreak'),
-                start: startingAt,
-                end: end.toISOString().split('T')[0],
-                allDay: true,
-                color: '#F85A6D',
-              });
-            } else {
-              const filtered = data.days.map((day) => ({
-                ...day,
-                events: (day.events ?? []).filter((e) => e.type !== 'Holiday'),
-              }));
-              allEvents.push(...mapZhawDaysToEvents({ days: filtered }));
-            }
-          }
+          const weekEvents = await fetchWeeklyOrMonthlyView(shortName, viewStart, viewEnd, viewType, t);
+          allEvents.push(...weekEvents);
         }
 
         successCallback(allEvents);
@@ -113,7 +91,7 @@ export function useCalendar(shortName: string) {
         failureCallback(err as Error);
       }
     },
-    [shortName, t]
+    [shortName, students, lecturers, t]
   );
 
   return {
@@ -121,7 +99,70 @@ export function useCalendar(shortName: string) {
     lecturers,
     loading,
     loadStudents,
-    loadLecturers, // currently unused
+    loadLecturers,
     fetchEventsDynamically,
   };
 }
+
+/**
+ * Fetch events for a daily view.
+ */
+const fetchDailyView = async (shortName: string, viewStart: Date, viewType: string) => {
+  const startingAt = viewStart.toISOString().split('T')[0];
+  const data = await fetchZhawSchedule(shortName, startingAt, viewType);
+  const filtered = data.days.map((day) => ({
+    ...day,
+    events: (day.events ?? []).filter((e) => e.type !== 'Holiday'),
+  }));
+
+  return mapZhawDaysToEvents({ days: filtered });
+};
+
+/**
+ * Fetch events for weekly or monthly view.
+ */
+const fetchWeeklyOrMonthlyView = async (
+  shortName: string,
+  viewStart: Date,
+  viewEnd: Date,
+  viewType: string,
+  t: (key: string) => string // pass translator function into helper
+) => {
+  const allEvents: EventInput[] = [];
+  const fetchedWeeks = new Set<string>();
+  const maxDays = 7;
+
+  for (let date = new Date(viewStart); date <= viewEnd; date.setDate(date.getDate() + maxDays)) {
+    const adjustedDate = new Date(date);
+    adjustedDate.setDate(adjustedDate.getDate() + 1);
+    const startingAt = adjustedDate.toISOString().split('T')[0];
+
+    if (fetchedWeeks.has(startingAt)) {continue;}
+    fetchedWeeks.add(startingAt);
+
+    const data = await fetchZhawSchedule(shortName, startingAt, viewType);
+    const isWeekEmpty =
+      !data.days || data.days.length === 0 ||
+      data.days.every((day) => !day.events || day.events.every((e) => e.type === 'Holiday'));
+
+    if (isWeekEmpty) {
+      const end = new Date(adjustedDate);
+      end.setDate(end.getDate() + 7);
+      allEvents.push({
+        title: t('semesterBreak'),
+        start: startingAt,
+        end: end.toISOString().split('T')[0],
+        allDay: true,
+        color: '#F85A6D',
+      });
+    } else {
+      const filtered = data.days.map((day) => ({
+        ...day,
+        events: (day.events ?? []).filter((e) => e.type !== 'Holiday'),
+      }));
+      allEvents.push(...mapZhawDaysToEvents({ days: filtered }));
+    }
+  }
+
+  return allEvents;
+};

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -1,0 +1,127 @@
+import { useCallback, useState } from 'react';
+import { fetchZhawSchedule, fetchZhawStudents, fetchZhawLecturers } from '@/lib/handlers/calendarHandler';
+import { fetchPublicHolidays } from '@/lib/api/openholidays';
+import { mapZhawDaysToEvents } from '@/lib/calendar';
+import type { EventInput, EventSourceFuncArg } from '@fullcalendar/core';
+import { useTranslation } from 'react-i18next';
+
+export function useCalendar(shortName: string) {
+  const [students, setStudents] = useState<string[]>([]);
+  const [lecturers, setLecturers] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { t } = useTranslation(['calendar']);
+
+  /**
+   * Load only the list of students.
+   */
+  const loadStudents = useCallback(async () => {
+    setLoading(true);
+    try {
+      const studentList = await fetchZhawStudents();
+      setStudents(studentList.students);
+      console.log('Loaded students:', studentList.students);
+    } catch (err) {
+      console.error('Failed to load students', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  /**
+   * Load the list of lecturers.
+   */
+  const loadLecturers = useCallback(async () => {
+    setLoading(true);
+    try {
+      const lecturerList = await fetchZhawLecturers();
+      setLecturers(lecturerList.lecturers.map((l) => l.shortName));
+      console.log('Loaded lecturers:', lecturerList.lecturers.map((l) => l.shortName));
+    } catch (err) {
+      console.error('Failed to load lecturers', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  /**
+   * Fetch dynamic calendar events.
+   */
+  const fetchEventsDynamically = useCallback(
+    async (
+      fetchInfo: EventSourceFuncArg,
+      successCallback: (events: EventInput[]) => void,
+      failureCallback: (error: Error) => void
+    ) => {
+      try {
+        const viewStart = new Date(fetchInfo.start ?? new Date());
+        const viewEnd = new Date(fetchInfo.end ?? new Date());
+        const viewType = (fetchInfo as { view?: { type?: string } }).view?.type ?? 'timeGridWeek';
+        const isDailyView = viewType === 'timeGridDay';
+        const allEvents: EventInput[] = [];
+        const fetchedWeeks = new Set<string>();
+        const maxDays = 7;
+
+        // Add Swiss public holidays
+        const publicHolidays = await fetchPublicHolidays(viewStart.getFullYear());
+        allEvents.push(...publicHolidays);
+
+        if (isDailyView) {
+          const startingAt = viewStart.toISOString().split('T')[0];
+          const data = await fetchZhawSchedule(shortName, startingAt, viewType);
+          const filtered = data.days.map((day) => ({
+            ...day,
+            events: (day.events ?? []).filter((e) => e.type !== 'Holiday'),
+          }));
+          allEvents.push(...mapZhawDaysToEvents({ days: filtered }));
+        } else {
+          for (let date = new Date(viewStart); date <= viewEnd; date.setDate(date.getDate() + maxDays)) {
+            const adjustedDate = new Date(date);
+            adjustedDate.setDate(adjustedDate.getDate() + 1);
+            const startingAt = adjustedDate.toISOString().split('T')[0];
+
+            if (fetchedWeeks.has(startingAt)) {continue;}
+            fetchedWeeks.add(startingAt);
+
+            const data = await fetchZhawSchedule(shortName, startingAt, viewType);
+            const isWeekEmpty =
+              !data.days || data.days.length === 0 ||
+              data.days.every((day) => !day.events || day.events.every((e) => e.type === 'Holiday'));
+
+            if (isWeekEmpty) {
+              const end = new Date(adjustedDate);
+              end.setDate(end.getDate() + 7);
+              allEvents.push({
+                title: t('semesterBreak'),
+                start: startingAt,
+                end: end.toISOString().split('T')[0],
+                allDay: true,
+                color: '#F85A6D',
+              });
+            } else {
+              const filtered = data.days.map((day) => ({
+                ...day,
+                events: (day.events ?? []).filter((e) => e.type !== 'Holiday'),
+              }));
+              allEvents.push(...mapZhawDaysToEvents({ days: filtered }));
+            }
+          }
+        }
+
+        successCallback(allEvents);
+      } catch (err) {
+        console.error('Error fetching events:', err);
+        failureCallback(err as Error);
+      }
+    },
+    [shortName, t]
+  );
+
+  return {
+    students,
+    lecturers,
+    loading,
+    loadStudents,
+    loadLecturers, // currently unused
+    fetchEventsDynamically,
+  };
+}

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -17,47 +17,36 @@ export function useCalendar(shortName: string) {
 
   const determineUserRole = useCallback(async () => {
     setLoading(true);
-    try {
-      const [studentList, lecturerList] = await Promise.all([
-        fetchZhawStudents(),
-        fetchZhawLecturers(),
-      ]);
 
-      if (studentList.students.includes(shortName)) {
-        setRolePath('students');
-      } else if (lecturerList.lecturers.some((l) => l.shortName === shortName)) {
-        setRolePath('lecturers');
-      } else {
-        setRolePath(null);
-      }
-    } catch (err) {
-      console.error('Failed to determine user role', err);
-      setRolePath(null); // fallback
-    } finally {
-      setLoading(false);
+    const [studentList, lecturerList] = await Promise.all([
+      fetchZhawStudents(),
+      fetchZhawLecturers(),
+    ]);
+
+    if (studentList.students.includes(shortName)) {
+      setRolePath('students');
+    } else if (lecturerList.lecturers.some((l) => l.shortName === shortName)) {
+      setRolePath('lecturers');
+    } else {
+      setRolePath(null);
     }
+
+    setLoading(false);
   }, [shortName]);
 
   const fetchEventsDynamically = useCallback(
     async (
       fetchInfo: EventSourceFuncArg,
-      successCallback: (events: EventInput[]) => void,
-      failureCallback: (error: Error) => void
-    ) => {
-      try {
-        const viewStart = new Date(fetchInfo.start ?? new Date());
-        const viewEnd = new Date(fetchInfo.end ?? new Date());
+      successCallback: (events: EventInput[]) => void    ) => {
+      const viewStart = new Date(fetchInfo.start ?? new Date());
+      const viewEnd = new Date(fetchInfo.end ?? new Date());
 
-        const [publicHolidays, scheduleEvents] = await Promise.all([
-          fetchPublicHolidays(viewStart.getFullYear()),
-          rolePath ? fetchScheduleEvents(shortName, viewStart, viewEnd, rolePath, t) : Promise.resolve([]),
-        ]);
+      const [publicHolidays, scheduleEvents] = await Promise.all([
+        fetchPublicHolidays(viewStart.getFullYear()),
+        rolePath ? fetchScheduleEvents(shortName, viewStart, viewEnd, rolePath, t) : Promise.resolve([]),
+      ]);
 
-        successCallback([...publicHolidays, ...scheduleEvents]);
-      } catch (err) {
-        console.error('Error fetching events:', err);
-        failureCallback(err as Error);
-      }
+      successCallback([...publicHolidays, ...scheduleEvents]);
     },
     [shortName, rolePath, t]
   );

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -23,24 +23,20 @@ export function useCalendar(shortName: string) {
       const studentList = await fetchZhawStudents();
       if (studentList.students.includes(shortName)) {
         setRolePath('students');
-        console.log('User identified as student');
 
         return;
       }
 
       const lecturerList = await fetchZhawLecturers();
-      console.log(lecturerList);
       const lecturerShortNames = (lecturerList?.lecturers ?? []).map((l) => l.shortName);
 
       if (lecturerShortNames.includes(shortName)) {
         setRolePath('lecturers');
-        console.log('User identified as lecturer');
         
         return;
       }
 
-      setRolePath(null); // guest/holidays only
-      console.log('User identified as external/guest (holidays only)');
+      setRolePath(null); // neither student nor lecturer
     } catch (err) {
       console.error('Failed to determine user role', err);
     } finally {

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -23,7 +23,7 @@ export const generateCalendarEvents = async (
   viewStart: Date,
   viewEnd: Date,
   rolePath: string,
-  t: (_key) => string
+  t: (key: string) => string
 ) => {
   const allEvents: EventInput[] = [];
   const fetchedWeeks = new Set<string>();

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,6 +1,6 @@
 import type { ZhawSchedule } from '@/types/calendar';
 import type { EventInput } from '@fullcalendar/core';
-import { fetchZhawSchedule} from '@/lib/handlers/calendarHandler';
+import { fetchZhawSchedule } from '@/lib/handlers/calendarHandler';
 
 /**
  * Fetches ZHAW schedule data for a given shortName and date range,
@@ -23,7 +23,7 @@ export const generateCalendarEvents = async (
   viewStart: Date,
   viewEnd: Date,
   rolePath: string,
-  t: (key: string) => string
+  t: (_key) => string
 ) => {
   const allEvents: EventInput[] = [];
   const fetchedWeeks = new Set<string>();

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,11 +1,74 @@
 import type { ZhawSchedule } from '@/types/calendar';
 import type { EventInput } from '@fullcalendar/core';
+import { fetchZhawSchedule} from '@/lib/handlers/calendarHandler';
+
+/**
+ * Fetches ZHAW schedule data for a given shortName and date range,
+ * processes each week, detects empty (holiday) weeks, and maps the results
+ * into FullCalendar-compatible events.
+ *
+ * - Splits the date range into 7-day chunks.
+ * - Marks full weeks as semester breaks if no non-holiday events exist.
+ * - Filters out holidays from normal event weeks.
+ *
+ * @param shortName The user's ZHAW shortName (username).
+ * @param viewStart Start date of the calendar view.
+ * @param viewEnd End date of the calendar view.
+ * @param rolePath Either 'students' or 'lecturers' to determine API route.
+ * @param t Translation function for i18n (used for labels like 'semesterBreak').
+ * @returns An array of FullCalendar EventInput objects.
+ */
+export const generateCalendarEvents = async (
+  shortName: string,
+  viewStart: Date,
+  viewEnd: Date,
+  rolePath: string,
+  t: (key: string) => string
+) => {
+  const allEvents: EventInput[] = [];
+  const fetchedWeeks = new Set<string>();
+  const maxDays = 7;
+
+  for (let date = new Date(viewStart); date <= viewEnd; date.setDate(date.getDate() + maxDays)) {
+    const adjustedDate = new Date(date);
+    adjustedDate.setDate(adjustedDate.getDate() + 1);
+    const startingAt = adjustedDate.toISOString().split('T')[0];
+
+    if (fetchedWeeks.has(startingAt)) {continue;}
+    fetchedWeeks.add(startingAt);
+
+    const data = await fetchZhawSchedule(shortName, startingAt, rolePath);
+    const isWeekEmpty =
+      !data.days || data.days.length === 0 ||
+      data.days.every((day) => !day.events || day.events.every((e) => e.type === 'Holiday'));
+
+    if (isWeekEmpty) {
+      const end = new Date(adjustedDate);
+      end.setDate(end.getDate() + 7);
+      allEvents.push({
+        title: t('semesterBreak'),
+        start: startingAt,
+        end: end.toISOString().split('T')[0],
+        allDay: true,
+        color: '#F85A6D',
+      });
+    } else {
+      const filtered = data.days.map((day) => ({
+        ...day,
+        events: (day.events ?? []).filter((e) => e.type !== 'Holiday'),
+      }));
+      allEvents.push(...mapZhawDaysToEvents({ days: filtered }));
+    }
+  }
+
+  return allEvents;
+};
 
 /**
  * Converts a ZHAW schedule object into an array of FullCalendar-compatible events.
  * Filters out invalid entries and handles holiday & all-day classification.
  */
-export function mapZhawDaysToEvents(data: ZhawSchedule): EventInput[] {
+function mapZhawDaysToEvents(data: ZhawSchedule): EventInput[] {
   return (data.days ?? []).flatMap((day) => {
     if (!Array.isArray(day.events)) {return [];}
 

--- a/src/lib/handlers/calendarHandler.ts
+++ b/src/lib/handlers/calendarHandler.ts
@@ -1,0 +1,4 @@
+
+// make request to /students  & /lecturer to get all students save in list 
+
+// weder noch dann leerer kalendar

--- a/src/lib/handlers/calendarHandler.ts
+++ b/src/lib/handlers/calendarHandler.ts
@@ -4,9 +4,9 @@ import type { ZhawSchedule, ZhawStudents, ZhawLecturers } from '@/types/calendar
 /**
  * Fetch schedule for a given student shortName and date.
  */
-export async function fetchZhawSchedule(shortName: string, startingAt: string): Promise<ZhawSchedule> {
-  const res = await fetch(`/api/calendar/students/${shortName}?startingAt=${startingAt}`);
-
+export async function fetchZhawSchedule(shortName: string, startingAt: string, rolePath: string) {
+  const res = await fetch(`/api/calendar/${rolePath}/${shortName}?startingAt=${startingAt}`);
+  
   return parseResponse<ZhawSchedule>(res);
 }
 

--- a/src/lib/handlers/calendarHandler.ts
+++ b/src/lib/handlers/calendarHandler.ts
@@ -1,4 +1,40 @@
 
-// make request to /students  & /lecturer to get all students save in list 
+// make request to /students to get all students save in list 
 
-// weder noch dann leerer kalendar
+// wenn nicht student dann leerer kalendar
+
+// get all students and all lectueres
+
+//getstudentbyshortname und lectuere 
+// 
+// getweekview/ monthview
+
+import { parseResponse } from '@/lib/api/parseResponse';
+import type { ZhawSchedule, ZhawStudents, ZhawLecturers } from '@/types/calendar';
+
+/**
+ * Fetch schedule for a given student shortName and date.
+ */
+export async function fetchZhawSchedule(shortName: string, startingAt: string, viewType: string): Promise<ZhawSchedule> {
+  const res = await fetch(`/api/calendar/students/${shortName}?startingAt=${startingAt}&view=${viewType}`);
+  
+  return parseResponse<ZhawSchedule>(res);
+}
+
+/**
+ * Fetch the list of all student shortNames.
+ */
+export async function fetchZhawStudents(): Promise<ZhawStudents> {
+  const res = await fetch(`/api/calendar/students`);
+
+  return parseResponse<ZhawStudents>(res);
+}
+
+/**
+ * Fetch the list of all lecturer shortNames.
+ */
+export async function fetchZhawLecturers(): Promise<ZhawLecturers> {
+  const res = await fetch(`/api/calendar/lecturers`);
+
+  return parseResponse<ZhawLecturers>(res);
+}

--- a/src/lib/handlers/calendarHandler.ts
+++ b/src/lib/handlers/calendarHandler.ts
@@ -4,9 +4,9 @@ import type { ZhawSchedule, ZhawStudents, ZhawLecturers } from '@/types/calendar
 /**
  * Fetch schedule for a given student shortName and date.
  */
-export async function fetchZhawSchedule(shortName: string, startingAt: string, viewType: string): Promise<ZhawSchedule> {
-  const res = await fetch(`/api/calendar/students/${shortName}?startingAt=${startingAt}&view=${viewType}`);
-  
+export async function fetchZhawSchedule(shortName: string, startingAt: string): Promise<ZhawSchedule> {
+  const res = await fetch(`/api/calendar/students/${shortName}?startingAt=${startingAt}`);
+
   return parseResponse<ZhawSchedule>(res);
 }
 

--- a/src/lib/handlers/calendarHandler.ts
+++ b/src/lib/handlers/calendarHandler.ts
@@ -1,14 +1,3 @@
-
-// make request to /students to get all students save in list 
-
-// wenn nicht student dann leerer kalendar
-
-// get all students and all lectueres
-
-//getstudentbyshortname und lectuere 
-// 
-// getweekview/ monthview
-
 import { parseResponse } from '@/lib/api/parseResponse';
 import type { ZhawSchedule, ZhawStudents, ZhawLecturers } from '@/types/calendar';
 

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -1,5 +1,6 @@
-// * Type definitions for ZHAW schedule and mapped calendar events
-
+/**
+ * Represents a single event entry in the ZHAW schedule (e.g., lecture, or holiday).
+ */
 export interface ZhawEvent {
     startTime: string;
     endTime: string;
@@ -9,17 +10,49 @@ export interface ZhawEvent {
     eventRealizations?: {
         room?: { name: string };
     }[];
-  }
-  
+}
+
+/**
+ * Represents one day in the ZHAW schedule, holding multiple events.
+ */
 export interface ZhawDay {
     date: string;
     events: ZhawEvent[];
-  }
-  
+}
+
+/**
+ * Represents the full schedule response from the ZHAW API, spanning multiple days.
+ */
 export interface ZhawSchedule {
     days: ZhawDay[];
-  }
-  
+}
+
+/**
+ * Represents the list of all student shortNames fetched from the ZHAW API.
+ */
+export interface ZhawStudents {
+    students: string[];
+}
+
+/**
+ * Represents a single lecturer with display name and system shortName.
+ */
+export interface Lecturer {
+    name: string;
+    shortName: string;
+}
+
+/**
+ * Represents the list of all lecturers fetched from the ZHAW API.
+ */
+export interface ZhawLecturers {
+    lec‌: string[] | PromiseLike<string[]>;
+    lecturers: Lecturer[];
+}
+
+/**
+ * Represents a calendar event formatted for the frontend calendar view (e.g., FullCalendar).
+ */
 export interface CalendarEvent {
     title: string;
     start: string;
@@ -29,18 +62,4 @@ export interface CalendarEvent {
     extendedProps?: {
       isHoliday?: boolean;
     };
-  }
-
-export interface ZhawStudents {
-    students: string[];
-  }
-
-export interface Lecturer {
-  name: string;
-  shortName: string;
-}
-
-export interface ZhawLecturers {
-  lec‌: string[] | PromiseLike<string[]>;
-  lecturers: Lecturer[];
 }

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -30,3 +30,17 @@ export interface CalendarEvent {
       isHoliday?: boolean;
     };
   }
+
+export interface ZhawStudents {
+    students: string[];
+  }
+
+export interface Lecturer {
+  name: string;
+  shortName: string;
+}
+
+export interface ZhawLecturers {
+  lec‌: string[] | PromiseLike<string[]>;
+  lecturers: Lecturer[];
+}


### PR DESCRIPTION
## Resolves #79

## Description

This PR addresses the feature request where only students could see their calendars before, and now ensures that lecturers can also test and use the app effectively.

- Decoupled the calendar logic into a handler and a custom React hook to improve code modularity and maintainability.
- Adapted the API route so that it matches the structure of the ZHAW API, making it easier to handle requests consistently.
- Implemented the logic for displaying lecturer schedules by integrating their data into the calendar.
- Added fallback handling: when the shortname does not match a student or lecturer, the calendar now shows only public holidays (empty otherwise), preventing errors.
- Refactored API calls for better error handling, especially to deal with cases when the ZHAW API returns a 400 error (such as outside semester times or invalid roles).
- Updated comments throughout the codebase to improve clarity and documentation.
- Added borders to calendar component to match the studyconnect design more.

## Checklist

Please make sure that the following items have been completed before submitting this pull request:

- [ ] All issue acceptance criteria are fulfilled
- [ ] All code has been properly tested
- [ ] All tests pass successfully
- [ ] Meets coding standards
- [ ] Code has been properly documented with comments
- [ ] Manual Testing was done by Developer and Reviewer
- [ ] Refactoring is done (if needed)
- [ ] Documentation (README/API/UX/ARC42) updated
- [ ] Related non-linked issue is updated
